### PR TITLE
Added a version constraint on bini gem

### DIFF
--- a/pushover.gemspec
+++ b/pushover.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |gem|
 
   # dependencies.
   gem.add_runtime_dependency 'yajl-ruby'
-  gem.add_runtime_dependency 'bini'
+  gem.add_runtime_dependency 'bini', '~> 0.6.0'
 end


### PR DESCRIPTION
A recent update to the `bini` gem, erniebrodeur/bini@8e4c38c20433521c3047ddaa8561d325143d44cb, has broken `pushover`. Here's a fix.
