### PR TITLE
fixing optional notification parameters

### DIFF
--- a/lib/pushover.rb
+++ b/lib/pushover.rb
@@ -63,9 +63,10 @@ module Pushover
   def notification(tokens={})
     tokens[:timestamp] = timestamp_magic tokens[:timestamp] if tokens[:timestamp]
     tokens[:priority]  = Pushover::Priority.parse tokens[:priority] if tokens[:priority]
+    tokens[:user]      ||= @user
+    tokens[:token]     ||= @token
 
-    response = HTTParty.post('https://api.pushover.net/1/messages.json', body:tokens)
-    response
+    HTTParty.post('https://api.pushover.net/1/messages.json', body:tokens)
   end
 
   # Return a [Hash] of sounds.

--- a/spec/lib/pushover_spec.rb
+++ b/spec/lib/pushover_spec.rb
@@ -57,6 +57,18 @@ describe "Pushover" do
         puts req.body hash_including(priority:'ajkasdfj')
       end
     end
+
+    it "can send a notification with preconfigured user and token" do
+      setup_webmocks
+      Pushover.configure do |c|
+        c.user = 'good_user'
+        c.token = 'good_token'
+      end
+      Pushover.notification message:'a message'
+      WebMock.should have_requested(:post, /.*api.pushover.net.*/).with do |req|
+        puts req.body hash_including(priority:'ajkasdfj')
+      end
+    end
   end
 
   describe "extra behavior" do


### PR DESCRIPTION
This pull request fixes the behavior where the following code did not work. Test included.

``` ruby
Pushover.configure do |config|
  config.user='USER_TOKEN'
  config.token='APP_TOKEN'
end

Pushover.notification(message: 'message', title: 'title')
```
