### PR TITLE
Bump HTTParty Version

### DIFF
--- a/lib/pushover/version.rb
+++ b/lib/pushover/version.rb
@@ -1,4 +1,4 @@
 module Pushover
 	# The current version of Pushover.
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end

--- a/pushover.gemspec
+++ b/pushover.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
 
   # dependencies.
   gem.add_runtime_dependency 'yajl-ruby', "= 1.1.0"
-  gem.add_runtime_dependency 'httparty', "= 0.11.0"
+  gem.add_runtime_dependency 'httparty', '~> 0.13.5'
   gem.add_runtime_dependency 'bini', "= 0.7.0"
 end


### PR DESCRIPTION
This bumps the version of HTTParty used and does not lock directly to it. 

This allows pushover to coexist nicer with other gems that use HTTParty.

All tests pass.