### PR TITLE
Dont lock gems

### DIFF
--- a/lib/pushover/version.rb
+++ b/lib/pushover/version.rb
@@ -1,4 +1,4 @@
 module Pushover
 	# The current version of Pushover.
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end

--- a/pushover.gemspec
+++ b/pushover.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
 
   # dependencies.
   gem.add_runtime_dependency 'yajl-ruby', "= 1.1.0"
-  gem.add_runtime_dependency 'httparty', "= 0.11.0"
+  gem.add_runtime_dependency 'httparty', '~> 0.13.5'
   gem.add_runtime_dependency 'bini', "= 0.7.0"
 end

--- a/pushover.gemspec
+++ b/pushover.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.has_rdoc = 'yard'
 
   # dependencies.
-  gem.add_runtime_dependency 'yajl-ruby', "= 1.1.0"
+  gem.add_runtime_dependency 'yajl-ruby', "~> 1.1.0"
   gem.add_runtime_dependency 'httparty', '~> 0.13.5'
-  gem.add_runtime_dependency 'bini', "= 0.7.0"
+  gem.add_runtime_dependency 'bini', "~> 0.7.0"
 end


### PR DESCRIPTION
This removes the locking of the other gems as well, to again help coexist with other libraries.

This shouldn't be merged until #21 is merged.