### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ require 'pushover'
 ### Create a message
 
 ```ruby
-message = Pushover.create {
+message = Pushover::Message.create(
   user: '...',
   token: '...',
   message: '...'
-}
+)
 ```
 
 ### Send the message
 
 ```ruby
-response = message.send
+response = message.push
 ```
 
 ### Response


### PR DESCRIPTION
Hi @erniebrodeur,

Today I tried to use v2.0.0 refer to README.md. But I could not use it.

It seems to be different from https://github.com/erniebrodeur/pushover/blob/v2.0.0/lib/pushover/message.rb

Thanks.