### PR TITLE
Fix NameError (uninitialized constant Pushover::VERSION)

### DIFF
--- a/lib/pushover.rb
+++ b/lib/pushover.rb
@@ -4,6 +4,7 @@ require 'excon'
 require 'pushover/message'
 require 'pushover/response'
 require 'pushover/receipt'
+require 'pushover/version'
 
 # pushover interface for ruby
 module Pushover


### PR DESCRIPTION
Fix the following error:

```
$ irb
irb(main):001:0> require 'pushover'
Traceback (most recent call last):
        9: from /Users/masutaka/.rbenv/versions/2.6.3/bin/irb:23:in `<main>'
        8: from /Users/masutaka/.rbenv/versions/2.6.3/bin/irb:23:in `load'
        7: from /Users/masutaka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        6: from (irb):1
        5: from /Users/masutaka/.rbenv/versions/2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:34:in `require'
        4: from /Users/masutaka/.rbenv/versions/2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `rescue in require'
        3: from /Users/masutaka/.rbenv/versions/2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `require'
        2: from /Users/masutaka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pushover-3.0.0/lib/pushover.rb:9:in `<top (required)>'
        1: from /Users/masutaka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pushover-3.0.0/lib/pushover.rb:11:in `<module:Pushover>'
NameError (uninitialized constant Pushover::VERSION)
```
