### PR TITLE
Need to include the version.

### DIFF
--- a/lib/pushover.rb
+++ b/lib/pushover.rb
@@ -1,6 +1,7 @@
 require 'oj'
 require 'excon'
 
+require 'pushover/version'
 require 'pushover/message'
 require 'pushover/response'
 require 'pushover/receipt'


### PR DESCRIPTION
The version is not included, so causes a Pushover::VERSION uninitialized variable error when attempting to use the gem.