### PR TITLE
Enforce minimum ruby version

### DIFF
--- a/pushover.gemspec
+++ b/pushover.gemspec
@@ -23,4 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'excon'
   spec.add_runtime_dependency 'gli'
   spec.add_runtime_dependency 'oj'
+
+  # minimum ruby version
+  spec.required_ruby_version = '~> 2.5'
 end


### PR DESCRIPTION
Will prevent people on incompatible versions of Ruby (2.4 and earlier) from installing the v3 series of the Pushover gem.

Fixes #36